### PR TITLE
Default create/update/recycleElement

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,7 @@ This property is invoked in these scenarios:
 * The developer changes the `totalItems` property.
 * The developer calls `requestReset()`, which will call `updateElement` for all currently-visible elements. See [below](#data-manipulation-using-requestreset) for why this can be useful.
 
-The default `updateElement` sets the textContent of the child to be the data index.
-
-For more on the interplay between `createElement` and `updateElement`, and when each is appropriate, see [the example below](#using-createelement-and-updateelement)
+The default `updateElement` sets the textContent of the child to be the data index. Almost all uses of `<virtual-scroller>` will want to change this behavior.
 
 ### `recycleElement` property
 
@@ -70,9 +68,9 @@ The default `recycleElement` collects the item's element if it is no longer visi
 
 Set this property to null to remove the item's element from the DOM when it is no longer visible, and to prevent recycling by the default `createElement`.
 
-Changing this property from its default will automatically reset `recycleElement` to null, if `recycleElement` has been left as its default.
+Changing this property from its default will automatically reset `createElement` to null, if `createElement` has been left as its default.
 
-This is often used for node-recycling scenarios, as seen in [the example below](#dom-recycling-using-recycleElement).
+Usually this property will be customized to introduce custom node recycling logic, as seen in [the example below](#dom-recycling-using-recycleElement).
 
 ### `elementKey` property
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,9 @@ The (tentative) API design choices made here, as well as the element's capabilit
   const scroller = document.querySelector('virtual-scroller');
   const myItems = new Array(200).fill('item');
 
-  // Setting this is required; without it the scroller does not function.
-  scroller.createElement = (index) => {
-    const child = document.createElement('section');
+  scroller.updateElement = (child, index) => {
     child.textContent = index + ' - ' + myItems[index];
     child.onclick = () => console.log(`clicked item #${index}`);
-    return child;
   };
 
   // This will automatically cause a render of the visible children
@@ -33,35 +30,7 @@ The (tentative) API design choices made here, as well as the element's capabilit
 </script>
 ```
 
-### Leverage default recycling
-
-By default `virtual-scroller` creates and recycles `<div>` children, and renders the data index.
-This snippet creates a list of divs displaying indexes from 0 to 99:
-```html
-<virtual-scroller totalitems="100"></virtual-scroller>
-```
-
-You can customize the rendering through `updateElement` property:
-```js
-virtualScroller.updateElement = (divElem, index) => {
-  divElem.textContent = index + ' - ' + myItems[index];
-};
-```
-
-You can customize the child type while still leveraging the recycling by distributing a `<template>` with the custom element into `virtual-scroller`:
-```html
-<virtual-scroller totalitems="100">
-  <template>
-    <contact-element sortable></contact-element>
-  </template>
-</virtual-scroller>
-
-<script type="module">
-  virtualScroller.updateElement = (contactElem, index) => {
-    contactElem.contact = getContactForIndex(index);
-  };
-</script>
-```
+By default, the elements inside the virtual scroller created in this example will be `<div>`s, and will be recycled. See below for more on customizing this behavior through the `createElement` and `recycleElement` APIs.
 
 Checkout more examples in [demo/index.html](./demo/index.html).
 
@@ -73,9 +42,9 @@ Type: `function(itemIndex: number) => Element`
 
 Set this property to configure the virtual scroller with a factory that creates an element the first time a given item at the specified index is ready to be displayed in the DOM.
 
-The default `createElement` searches for a `<template>` child, and if none, it creates a generic `<div>`. It reuses recycled DOM nodes collected by the default `recycleElement`. 
+The default `createElement` will, upon first being invoked, search for the first `<template>` element child that itself has at least one child element in its template contents. If one exists, it will create new elements by cloning that child. Otherwise, it will create `<div>` elements. In either case, it will reuse recycled DOM nodes if `recycleElement` is left as its default value.
 
-Changing this property will automatically set the default `recycleElement` to null.
+Changing this property from its default will automatically reset `recycleElement` to null, if `recycleElement` has been left as its default.
 
 ### `updateElement` property
 
@@ -97,11 +66,11 @@ For more on the interplay between `createElement` and `updateElement`, and when 
 
 Type: `function(child: Element, itemIndex: number)`
 
-The default `recycleElement` collects the item's element no longer visible and keeps it on the DOM in order to be reused by the default `createElement`. 
+The default `recycleElement` collects the item's element if it is no longer visible, and leaves it connected to the DOM in order to be reused by the default `createElement`.
 
-Set this property to null to discart and remove the item's element from the DOM when no longer visible.
+Set this property to null to remove the item's element from the DOM when it is no longer visible, and to prevent recycling by the default `createElement`.
 
-Changing this property will automatically set the default `createElement` to null.
+Changing this property from its default will automatically reset `recycleElement` to null, if `recycleElement` has been left as its default.
 
 This is often used for node-recycling scenarios, as seen in [the example below](#dom-recycling-using-recycleElement).
 
@@ -155,14 +124,67 @@ Also see [the example below](#performing-actions-as-the-scroller-scrolls-using-t
 
 ## More examples
 
-### Using `createElement` and `updateElement`
+### Customizing element creation and updating with `<template>`
 
-The rule of thumb for these two options is:
+If the user does nothing special, the default `createElement` callback will create and reuse `<div>` elements. There are several ways of getting more control over this process.
 
-* You always have to set `createElement`. It is responsible for actually creating the DOM elements corresponding to each item.
-* You should set `updateElement` if you ever plan on updating the data items.
+First, you can use a `<template>` child element to declaratively set up your new element. This snippet creates a scrolling view onto `<section>` elements, which (per the default `updateElement` behavior) display indices from 0 to 99:
 
-Thus, for completely static lists, you only need to set `createElement`:
+```html
+<virtual-scroller totalitems="100">
+  <template>
+    <section></section>
+  </template>
+</virtual-scroller>
+```
+
+By setting a custom `updateElement` behavior, you can leverage more interesting templates, for example:
+
+```html
+<virtual-scroller id="scroller">
+  <template>
+    <section>
+      <h1></h1>
+      <img></img>
+      <p></p>
+    </section>
+  </template>
+</virtual-scroller>
+
+<script type="module">
+  scroller.updateElement = (child, index) => {
+    child.querySelector("h1") = contacts[index].name;
+    child.querySelector("img").src = contacts[index].avatarURL;
+    child.querySelector("p").textContent = contacts[index].bio;
+  };
+
+  scroller.totalItems = contacts.length;
+</script>
+```
+
+A useful pattern here is to encapsulate the details of updating your elements inside a custom element, for example:
+
+```html
+<virtual-scroller>
+  <template>
+    <contact-element sortable></contact-element>
+  </template>
+</virtual-scroller>
+
+<script type="module">
+  scroller.updateElement = (child, index) => {
+    child.contact = contacts[index];
+  };
+
+  scroller.totalItems = contacts.length;
+</script>
+```
+
+Note that in all these examples, the elements are recycled.
+
+### Customizing element creation and updating: using `createElement`
+
+If you want complete control over element creation, you can set a custom `createElement`. This could be useful if, for example, you have a completely static list, which you want to fill out ahead of time and never update again:
 
 ```js
 let myItems = ['a', 'b', 'c', 'd'];
@@ -173,13 +195,13 @@ scroller.createElement = index => {
   return child;
 };
 
+scroller.updateElement = null;
+
 // Calls createElement four times (assuming the screen is big enough)
 scroller.totalItems = myItems.length;
 ```
 
-In this example, we are statically displaying a virtual scroller with four items, which we never plan to update. This can be useful for use cases where you would otherwise use static HTML, but want to get the performance benefits of virtualization. (Admittedly, we'd need more than four items to see that happen in reality.)
-
-Note that even if we invoke `requestReset()`, nothing new would render in this case:
+Note that even if we invoke `requestReset()`, nothing new would render in this case, because we have no `updateElement` behavior:
 
 ```js
 // Does nothing
@@ -191,37 +213,13 @@ requestAnimationFrame(() => {
 
 _Note: we include `requestAnimationFrame` here to wait for `<virtual-scroller>` rendering._
 
-If you plan to update your items, you're likely better off using `createElement` to set up the "template" for each item, and using `updateElement` to fill in the data. Like so:
+### Custom DOM recycling using `recycleElement`
 
-```js
-// Leverage the default `createElement` which creates a generic `<div>`.
-
-scroller.updateElement = (child, index) => {
-  child.textContent = myItems[index];
-};
-
-let myItems = ['a', 'b', 'c', 'd'];
-// Calls createElement + updateElement four times
-scroller.totalItems = myItems.length;
-
-// This now works: it calls updateElement four times
-requestAnimationFrame(() => {
-  myItems = ['A', 'B', 'C', 'D'];
-  scroller.requestReset();
-});
-```
-
-### DOM recycling using `recycleElement`
-
-You can recycle DOM by using the `recycleElement` function to collect DOM, and reuse it in `createElement`.
-
-When doing this, be sure to perform DOM updates in `updateElement`, as recycled children will otherwise have the data from the previous item.
+The default `createElement` and `recycleElement` functions will recycle the created DOM elements. You can also control this process on your own by setting a custom `recycleElement`:
 
 ```js
 const myItems = ['a', 'b', 'c', 'd'];
 
-// By default virtual-scroller creates and recycles `<div>` children, 
-// but we want to generate `<section>` children and control the recycling.
 const nodePool = [];
 scroller.createElement = (index) => {
   return nodePool.pop() || document.createElement('section');
@@ -236,6 +234,16 @@ scroller.updateElement = (child, index) => {
 
 scroller.totalItems = myItems.length;
 ```
+
+This example's only customization over the default is using `<section>` instead of `<div>`. So, it is equivalent to only setting `updateElement` and then using
+
+```html
+<virtual-scroller>
+  <template><section></section></template>
+</virtual-scroller>
+```
+
+But at least it illustrates the idea, and gives you a starting point for more advanced customizations.
 
 ### Data manipulation using `requestReset()`
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,6 @@ The default `recycleElement` collects the item's element if it is no longer visi
 
 Set this property to null to remove the item's element from the DOM when it is no longer visible, and to prevent recycling by the default `createElement`.
 
-Changing this property from its default will automatically reset `createElement` to null, if `createElement` has been left as its default.
-
 Usually this property will be customized to introduce custom node recycling logic, as seen in [the example below](#dom-recycling-using-recycleElement).
 
 ### `elementKey` property

--- a/demo/contacts/contact-element.js
+++ b/demo/contacts/contact-element.js
@@ -1,3 +1,6 @@
+const emptyImg =
+    'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+
 class ContactElement extends HTMLElement {
   connectedCallback() {
     if (this.shadowRoot) {
@@ -73,11 +76,9 @@ class ContactElement extends HTMLElement {
     if (!this.shadowRoot)
       return;
     const contact = this.contact || {};
-    if (contact.image) {
-      this._img.src = contact.image;
-    }
+    this._img.src = contact.image || emptyImg;
     this._label.textContent = contact.name;
-    this._label.style.color = contact.color;
+    this._label.style.color = contact.color || null;
     this._counter.textContent = `render count: ${++this._renderCount}`;
   }
 }

--- a/demo/fallback.html
+++ b/demo/fallback.html
@@ -44,7 +44,11 @@
     </label>
   </p>
 
-  <virtual-scroller></virtual-scroller>
+  <virtual-scroller>
+    <template>
+      <contact-element onclick="toggleExpanded(this)"></contact-element>
+    </template>
+  </virtual-scroller>
 
   <script type="module">
     import '../virtual-scroller-element.js';
@@ -64,17 +68,11 @@
     const dataSource = new ContactDataSource();
     const virtualScroller = document.querySelector('virtual-scroller');
 
-    virtualScroller.createElement = () => document.createElement('contact-element');
     virtualScroller.updateElement = (element, index) => {
       const contact = contacts[index];
-      element.style.animation = contact.customAnimation || null;
       element.contact = contact;
+      element.style.animation = contact.customAnimation || null;
       element.style.height = contact.expanded ? '160px' : null;
-      // Expand/collapse only on loaded contacts.
-      element.onclick = contact.customAnimation ? null : () => {
-        contact.expanded = !contact.expanded;
-        element.style.height = contact.expanded ? '160px' : null;
-      };
     };
 
     // Generate enough fallbacks to cover the viewport height.
@@ -109,6 +107,15 @@
         virtualScroller.totalItems += newContacts.length;
       }
     });
+
+    window.toggleExpanded = (contactElem) => {
+      const contact = contactElem.contact;
+      // Toggle only on loaded contacts.
+      if (!contact.customAnimation) {
+        contact.expanded = !contact.expanded;
+        contactElem.style.height = contact.expanded ? '160px' : null;
+      }
+    };
 
     window.updateDelay = (delayEl) => {
       let delay = delayEl.valueAsNumber;

--- a/demo/sorting.html
+++ b/demo/sorting.html
@@ -28,11 +28,15 @@
 <body>
 
   <label>
-    <input type="checkbox" onchange="toggleelementKey(this.checked)"> Use
+    <input type="checkbox" onchange="toggleElementKey(this.checked)"> Use
     <code>contact.guid</code> as
     <code>elementKey</code>
   </label>
-  <virtual-scroller></virtual-scroller>
+  <virtual-scroller>
+    <template>
+      <contact-element sortable></contact-element>
+    </template>
+  </virtual-scroller>
 
   <script type="module">
     import '../virtual-scroller-element.js';
@@ -40,14 +44,13 @@
 
     const virtualScroller = document.querySelector('virtual-scroller');
 
-    virtualScroller.createElement = () => {
-      const element = document.createElement('contact-element');
-      element.setAttribute('sortable', '');
-      element.addEventListener('moveup', (event) => moveContact(event.target.contact, -1));
-      element.addEventListener('movedown', (event) => moveContact(event.target.contact, 1));
-      return element;
+    const onMoveup = (event) => moveContact(event.target.contact, -1);
+    const onMovedown = (event) => moveContact(event.target.contact, 1);
+    virtualScroller.updateElement = (element, index) => {
+      element.addEventListener('moveup', onMoveup);
+      element.addEventListener('movedown', onMovedown);
+      element.contact = myContacts[index];
     };
-    virtualScroller.updateElement = (element, index) => element.contact = myContacts[index];
 
     let myContacts = null;
     fetch('contacts/contacts.json').then((resp) => resp.json()).then((contacts) => {
@@ -63,7 +66,7 @@
       virtualScroller.requestReset(); // notify virtual-scroller
     }
 
-    window.toggleelementKey = function toggleelementKey(useGuid) {
+    window.toggleElementKey = function toggleElementKey(useGuid) {
       virtualScroller.elementKey = useGuid ? (index) => myContacts[index].guid : null;
     };
   </script>

--- a/virtual-scroller-element.js
+++ b/virtual-scroller-element.js
@@ -22,7 +22,7 @@ export class VirtualScrollerElement extends HTMLElement {
     let childTemplate = null;
     const createElement = () => {
       if (!childTemplate) {
-        const template = this.querySelector('template');
+        const template = this.querySelector('> template');
         childTemplate = template && template.content.firstElementChild ?
             template.content.firstElementChild :
             document.createElement('div');

--- a/virtual-scroller-element.js
+++ b/virtual-scroller-element.js
@@ -25,7 +25,7 @@ export class VirtualScrollerElement extends HTMLElement {
         return this[_nodePool].pop();
       }
       if (!childTemplate) {
-        const template = this.querySelector('> template');
+        const template = this.querySelector('template');
         childTemplate = template && template.content.firstElementChild ?
             template.content.firstElementChild :
             document.createElement('div');

--- a/virtual-scroller-element.js
+++ b/virtual-scroller-element.js
@@ -25,7 +25,7 @@ export class VirtualScrollerElement extends HTMLElement {
         return this[_nodePool].pop();
       }
       if (!childTemplate) {
-        const template = this.querySelector('template');
+        const template = this.querySelector('> template');
         childTemplate = template && template.content.firstElementChild ?
             template.content.firstElementChild :
             document.createElement('div');


### PR DESCRIPTION
Fixes #80.
With these new defaults, the user only needs to set `updateElement` to effectively customize the rendering. 
`virtual-scroller` creates a `<div>` as a child template, but this can be customized by distributing a `<template>` with any element into the scroller. The scroller will recycle these children by default.

Updated README.md and couple demos as an example of usage.