### PR TITLE
implement scrollToIndex()

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -209,7 +209,7 @@ layout.scrollToIndex(9, 'center');
 layout.scrollToIndex(19, 'end');
 
 // Scroll to the 100th item, position it at the end of the viewport 
-// if we are scrolled above it already, otherwisef position it to the start.
+// if we are scrolled above it already, otherwise position it to the start.
 layout.scrollToIndex(99, 'nearest');
 
 ```

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -186,13 +186,32 @@ layout.updateItemSizes({
 });
 ```
 
-Set `layout.viewportScroll` to move the range across the container size.
+### Move range
+
+Use `viewportScroll (type: {top: number, left: number})` to move the range to a specific point.
 ```js
 const el = document.scrollingElement;
 el.addEventListener('scroll', () => {
   layout.viewportScroll = {top: el.scrollTop};
   layout.reflowIfNeeded();
 });
+```
+
+Use `scrollToIndex(index: number, position: string)` to move the range to a specific index.
+```js
+// Scroll to the 3rd item, position it at the start of the viewport.
+layout.scrollToIndex(2);
+
+// Scroll to the 10th item, position it at the center of the viewport.
+layout.scrollToIndex(9, 'center');
+
+// Scroll to the 20th item, position it at the end of the viewport.
+layout.scrollToIndex(19, 'end');
+
+// Scroll to the 100th item, position it at the end of the viewport 
+// if we are scrolled above it already, otherwisef position it to the start.
+layout.scrollToIndex(99, 'nearest');
+
 ```
 
 ## VirtualScroller (RepeatsAndScrolls mixin)

--- a/README.md
+++ b/README.md
@@ -97,16 +97,20 @@ This re-renders all of the currently-displayed elements, updating them from thei
 
 This generally needs to be called any time the data to be displayed changes. This includes additions, removals, and modifications to the data. See our [examples below](#data-manipulation-using-itemschanged) for more information.
 
-### `scrollToIndex(index: number, position: string = "start")` method
+### `scrollToIndex(index: number, { position: string = "start" } = {})` method
 
 Scrolls to a specified index, optionally with a position, one of:
 
-* "start" (default)
-* "center"
-* "end"
-* "nearest"
+* `"start"`: aligns the start of the item with the start of the visible portion of the scroller
+* `"center"`: aligns the center of the item with the center of the visible portion of the scroller
+* `"end"`: aligns the end of the item with the end of the visible portion of the scroller
+* `"nearest"`: if the item is before the center of the visible portion of the scroller, behaves like `"start"`; if it is after the center of the visible portion of the scroller, behaves like `"end"`
 
-See [demo/scrolling.html](demo/scrolling.html) as an example implementation.
+Note that what is considered the "start" and "end" of the scroller is dependent on the layout; for vertical layouts, start/end means top/bottom, while for horizontal layouts, they mean left/right.
+
+See [demo/scrolling.html](demo/scrolling.html) to see these behaviors in action.
+
+_Note: the options object design is inspired by [the options for `element.scrollIntoView()`](https://drafts.csswg.org/cssom-view/#dictdef-scrollintoviewoptions). We may in the future add a `behavior` option for smooth scrolling; see [#99](https://github.com/valdrinkoshi/virtual-scroller/issues/99)._
 
 ### "`rangechange`" event
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,17 @@ This re-renders all of the currently-displayed elements, updating them from thei
 
 This generally needs to be called any time the data to be displayed changes. This includes additions, removals, and modifications to the data. See our [examples below](#data-manipulation-using-itemschanged) for more information.
 
+### `scrollToIndex(index: number, position: string = "start")` method
+
+Scrolls to a specified index, optionally with a position, one of:
+
+* "start" (default)
+* "center"
+* "end"
+* "nearest"
+
+See [demo/scrolling.html](demo/scrolling.html) as an example implementation.
+
 ### "`rangechange`" event
 
 Bubbles: false / Cancelable: false / Composed: false

--- a/demo/index.html
+++ b/demo/index.html
@@ -28,6 +28,9 @@
     <li>
       <a href="header-footer.html">Custom headers/footers</a>
     </li>
+    <li>
+      <a href="scrolling.html">Scroll to item</a>
+    </li>
   </ul>
 
   <h2>Other examples</h2>

--- a/demo/scrolling.html
+++ b/demo/scrolling.html
@@ -71,13 +71,13 @@
       .then((resp) => resp.json())
       .then((contacts) => virtualScroller.itemSource = contacts);
 
-    window.scrollToIndex = function(index, position) {
+    window.scrollToIndex = (index, position) => {
       if (index >= 0 && index < virtualScroller.itemSource.length) {
         virtualScroller.scrollToIndex(index, position);
       }
     };
 
-    window.toggleHorizontal = function(horizontal) {
+    window.toggleHorizontal = (horizontal) => {
       virtualScroller.layout = horizontal ? 'horizontal' : 'vertical';
     };
   </script>

--- a/demo/scrolling.html
+++ b/demo/scrolling.html
@@ -72,10 +72,7 @@
       .then((contacts) => virtualScroller.itemSource = contacts);
 
     window.scrollToIndex = (index, position) => {
-      // TODO: virtual-scroller should probably handle this clamping itself?
-      if (index >= 0 && index < virtualScroller.itemSource.length) {
-        virtualScroller.scrollToIndex(index, { position });
-      }
+      virtualScroller.scrollToIndex(index, { position });
     };
 
     window.toggleHorizontal = (horizontal) => {

--- a/demo/scrolling.html
+++ b/demo/scrolling.html
@@ -1,0 +1,86 @@
+<html>
+
+<head>
+  <title>Scrolling</title>
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+
+  <style>
+    body {
+      font-family: Roboto, Helvetica, sans-serif;
+      display: flex;
+      flex-direction: column;
+    }
+
+    #controls {
+      margin: 10px 0;
+    }
+
+    input {
+      width: 50px;
+    }
+
+    virtual-scroller {
+      flex: 1;
+      height: 100%;
+      box-sizing: border-box;
+      border-top: 2px solid #eee;
+      border-bottom: 2px solid #eee;
+    }
+
+    virtual-scroller>div {
+      padding: 10px;
+      box-sizing: border-box;
+      border-bottom: 1px solid #eee;
+    }
+
+    [layout="horizontal"]>div {
+      writing-mode: vertical-lr;
+    }
+  </style>
+</head>
+
+<body>
+
+  <div id="controls">
+    <label>
+      Scroll to:
+      <input id="index" type="number" placeholder="index" onchange="scrollToIndex(this.valueAsNumber, position.value)">
+      <select id="position" onchange="scrollToIndex(index.valueAsNumber, this.value)">
+        <option value="start">start</option>
+        <option value="end">end</option>
+        <option value="center">center</option>
+        <option value="nearest">nearest</option>
+      </select>
+    </label>
+    <label>
+      horizontal:
+      <input type="checkbox" onchange="toggleHorizontal(this.checked)">
+    </label>
+  </div>
+  <virtual-scroller id="scroller"></virtual-scroller>
+
+  <script type="module">
+    import '../virtual-scroller-element.js';
+
+    const virtualScroller = document.getElementById('scroller');
+
+    virtualScroller.updateElement = (element, contact, index) =>
+      element.textContent = `${index}) ${contact.longText}`;
+
+    fetch('contacts/contacts.json')
+      .then((resp) => resp.json())
+      .then((contacts) => virtualScroller.itemSource = contacts);
+
+    window.scrollToIndex = function(index, position) {
+      if (index >= 0 && index < virtualScroller.itemSource.length) {
+        virtualScroller.scrollToIndex(index, position);
+      }
+    };
+
+    window.toggleHorizontal = function(horizontal) {
+      virtualScroller.layout = horizontal ? 'horizontal' : 'vertical';
+    };
+  </script>
+</body>
+
+</html>

--- a/demo/scrolling.html
+++ b/demo/scrolling.html
@@ -72,8 +72,9 @@
       .then((contacts) => virtualScroller.itemSource = contacts);
 
     window.scrollToIndex = (index, position) => {
+      // TODO: virtual-scroller should probably handle this clamping itself?
       if (index >= 0 && index < virtualScroller.itemSource.length) {
-        virtualScroller.scrollToIndex(index, position);
+        virtualScroller.scrollToIndex(index, { position });
       }
     };
 

--- a/layouts/layout-1d-base.js
+++ b/layouts/layout-1d-base.js
@@ -292,8 +292,7 @@ export default class Layout extends EventTarget {
 
   _scrollPositionChanged(oldPos, newPos) {
     // When both values are bigger than the max scroll position, keep the
-    // current scroll anchor. Otherwise, invalidate it so it can be recomputed
-    // in the next reflow.
+    // current _scrollToIndexx, otherwise invalidate it.
     const maxPos = this._scrollSize - this._viewDim1;
     if (oldPos < maxPos || newPos < maxPos) {
       this._scrollToIndex = -1;

--- a/layouts/layout-1d-base.js
+++ b/layouts/layout-1d-base.js
@@ -155,6 +155,9 @@ export default class Layout extends EventTarget {
   }
 
   scrollToIndex(index, position = 'start') {
+    if (!Number.isFinite(index))
+      return;
+    index = Math.min(this.totalItems, Math.max(0, index));
     this._scrollToIndex = index;
     if (position === 'nearest') {
       position = index > this._first + this._num / 2 ? 'end' : 'start';

--- a/layouts/layout-1d-grid.js
+++ b/layouts/layout-1d-grid.js
@@ -23,8 +23,6 @@ export default class Layout extends Layout1dBase {
   }
 
   _getActiveItems() {
-    const {_scrollPosition, _scrollSize} = this;
-
     const min = Math.max(0, this._scrollPosition - this._overhang);
     const max = Math.min(
         this._scrollSize,

--- a/layouts/layout-1d.js
+++ b/layouts/layout-1d.js
@@ -10,7 +10,6 @@ export default class Layout extends Layout1dBase {
 
     this._anchorIdx = null;
     this._anchorPos = null;
-    this._scrollError = 0;
     this._stable = true;
 
     this._needsRemeasure = false;
@@ -295,6 +294,7 @@ export default class Layout extends Layout1dBase {
 
     this._updateScrollSize();
     this._getActiveItems();
+    this._scrollIfNeeded();
 
     if (this._scrollSize !== _scrollSize) {
       this._emitScrollSize();
@@ -326,6 +326,13 @@ export default class Layout extends Layout1dBase {
       [this._positionDim]: this._getPosition(idx),
           [this._secondaryPositionDim]: 0
     }
+  }
+
+  _getItemSize(idx) {
+    return {
+      [this._sizeDim]: this._getSize(idx) || this._itemDim1,
+      [this._secondarySizeDim]: this._itemDim2,
+    };
   }
 
   _viewDim2Changed() {

--- a/virtual-scroller-element.js
+++ b/virtual-scroller-element.js
@@ -157,7 +157,7 @@ export class VirtualScrollerElement extends HTMLElement {
     }
   }
 
-  scrollToIndex(index, position = 'start') {
+  scrollToIndex(index, { position = 'start' } = {}) {
     if (this[_scroller]) {
       this[_scroller].layout.scrollToIndex(index, position);
     }

--- a/virtual-scroller-element.js
+++ b/virtual-scroller-element.js
@@ -157,6 +157,12 @@ export class VirtualScrollerElement extends HTMLElement {
     }
   }
 
+  scrollToIndex(index, position = 'start') {
+    if (this[_scroller]) {
+      this[_scroller].layout.scrollToIndex(index, position);
+    }
+  }
+
   [_render]() {
     // Wait first connected as scroller needs to measure
     // sizes of container and children.


### PR DESCRIPTION
Fixes #88 by providing `scrollToIndex()` method, documentation and demo. This works both with all layouts we ship.

@domenic feel free to update the README.md as you see fit.

We invalidate the `_scrollToIndex` only when receiving scroll position changes (in other words, when user scrolls).


This implementation differs from #64 in the following: we don't compute the scroll anchor when user scrolls, nor allow customizing anchoring via itemAnchor and viewportAnchor.