### PR TITLE
Formatting / spacing; removes unused properties, commented code; etc.

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,12 +1,18 @@
 # Virtual Scroller pieces
 
-This document gives an overview of various pieces we use to build up the `<virtual-scroller>` element. For now we are considering these implementation details. A future proposal may expose these building blocks more directly, but only after significant refinement.
+This document gives an overview of various pieces we use to build up the
+`<virtual-scroller>` element. For now we are considering these implementation
+details. A future proposal may expose these building blocks more directly, but
+only after significant refinement.
 
 ## VirtualRepeater (Repeats mixin)
 
-- Orchestrates DOM creation and layouting, ensures minimum number of nodes is created.
-- Given a `totalItems` amount, it displays `num` elements starting from `first` index.
-- Delegates DOM creation, update and recycling via `createElement, updateElement, recycleElement`.
+- Orchestrates DOM creation and layouting, ensures minimum number of nodes is
+  created.
+- Given a `totalItems` amount, it displays `num` elements starting from `first`
+  index.
+- Delegates DOM creation, update and recycling via `createElement,
+  updateElement, recycleElement`.
 - Delegates DOM layout via `_measureCallback`.
 
 ### Basic setup
@@ -42,8 +48,8 @@ const repeater = new VirtualRepeater({
 
 ### Recycling
 
-You can recycle DOM through the `recycleElement`, and use the recycled DOM
-in `createElement`.
+You can recycle DOM through the `recycleElement`, and use the recycled DOM in
+`createElement`.
 
 If you decide to keep the recycled DOM attached in the main document, perform
 DOM updates in `updateElement`.
@@ -90,7 +96,10 @@ setTimeout(() => {
 
 ### Data manipulation
 
-VirtualRepeater will update the DOM when `totalItems` changes. For cases where data changes while keeping the same `totalItems`, or a specific item changes, you can use `requestReset()` to notify of the changes, or force `totalItems` change.
+VirtualRepeater will update the DOM when `totalItems` changes. For cases where
+data changes while keeping the same `totalItems`, or a specific item changes,
+you can use `requestReset()` to notify of the changes, or force `totalItems`
+change.
 
 ```js
 /**
@@ -113,8 +122,9 @@ Set to true to disable DOM additions/removals done by VirtualRepeater.
 
 #### _measureCallback()
 
-You can receive child layout information through `_measureCallback`,
-which will get invoked after each rendering.
+You can receive child layout information through `_measureCallback`, which will
+get invoked after each rendering.
+
 ```js
 repeater._measureCallback = (measuresInfo) => {
   for (const itemIndex in measuresInfo) {
@@ -127,7 +137,8 @@ repeater._measureCallback = (measuresInfo) => {
 
 ## Layout
 
-Given a viewport size and total items count, it computes children position, container size, range of visible items, and scroll error.
+Given a viewport size and total items count, it computes children position,
+container size, range of visible items, and scroll error.
 
 ```js
 const layout = new Layout({
@@ -146,7 +157,9 @@ const layout = new Layout({
 
 Apply changes by invoking `layout.reflowIfNeeded()`.
 
-It notifies subscribers about changes on range (e.g. `first, num`), item position, scroll size, scroll error. It's up to the listeners to take action on these.
+It notifies subscribers about changes on range (e.g. `first, num`), item
+position, scroll size, scroll error. It's up to the listeners to take action on
+these.
 
 ```js
 layout.addEventListener('rangechange', (event) => {
@@ -177,7 +190,9 @@ layout.addEventListener('scrollerrorchange', (event) => {
 layout.reflowIfNeeded();
 ```
 
-Use `layout.updateItemSizes()` to give layout more information regarding item sizes.
+Use `layout.updateItemSizes()` to give layout more information regarding item
+sizes.
+
 ```js
 // Pass an object with key = item index, value = bounds.
 layout.updateItemSizes({
@@ -188,7 +203,9 @@ layout.updateItemSizes({
 
 ### Move range
 
-Use `viewportScroll (type: {top: number, left: number})` to move the range to a specific point.
+Use `viewportScroll(type: {top: number, left: number})` to move the range to a
+specific point.
+
 ```js
 const el = document.scrollingElement;
 el.addEventListener('scroll', () => {
@@ -197,7 +214,9 @@ el.addEventListener('scroll', () => {
 });
 ```
 
-Use `scrollToIndex(index: number, position: string)` to move the range to a specific index.
+Use `scrollToIndex(index: number, position: string)` to move the range to a
+specific index.
+
 ```js
 // Scroll to the 3rd item, position it at the start of the viewport.
 layout.scrollToIndex(2);
@@ -216,10 +235,14 @@ layout.scrollToIndex(99, 'nearest');
 
 ## VirtualScroller (RepeatsAndScrolls mixin)
 
-- Extends `VirtualRepeater`, delegates the updates of `first, num` to a `Layout` instance
-- Exposes a `layout` property, updates the `layout.totalItems`, `layout.viewportSize`, and `layout.viewportScroll`.
-- Subscribes to `layout` updates on range (`first, num`), children position, scrolling position and scrolling size
-- Updates the container size (`min-width/height`) and children positions (`position: absolute`)
+- Extends `VirtualRepeater`, delegates the updates of `first, num` to a
+  `Layout` instance.
+- Exposes a `layout` property, updates the `layout.totalItems`,
+  `layout.viewportSize`, and `layout.viewportScroll`.
+- Subscribes to `layout` updates on range (`first, num`), children position,
+  scrolling position and scrolling size.
+- Updates the container size (`min-width/height`) and children positions
+  (`position: absolute`).
 
 ```js
 const scroller = new VirtualScroller({

--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
 # &lt;virtual-scroller&gt;
 
-`<virtual-scroller>` maps a provided set of JavaScript objects onto DOM nodes, and renders only the DOM nodes that are currently visible, leaving the rest "virtualized".
+`<virtual-scroller>` maps a provided set of JavaScript objects onto DOM nodes,
+and renders only the DOM nodes that are currently visible, leaving the rest
+"virtualized".
 
-This document is an early-stage explainer for `<virtual-scroller>` as a potential future web platform feature, as part of the [layered API](https://github.com/drufball/layered-apis) project. The repository also hosts a proof-of-concept implementation that is being co-evolved with the design.
+This document is an early-stage explainer for `<virtual-scroller>` as a
+potential future web platform feature, as part of the [layered
+API](https://github.com/drufball/layered-apis) project. The repository also
+hosts a proof-of-concept implementation that is being co-evolved with the
+design.
 
-The (tentative) API design choices made here, as well as the element's capabilities, take inspiration from the [infinite list study group](https://github.com/domenic/infinite-list-study-group) research.
+The (tentative) API design choices made here, as well as the element's
+capabilities, take inspiration from the [infinite list study
+group](https://github.com/domenic/infinite-list-study-group) research.
 
 ## Example
 
@@ -30,7 +38,9 @@ The (tentative) API design choices made here, as well as the element's capabilit
 </script>
 ```
 
-By default, the elements inside the virtual scroller created in this example will be `<div>`s, and will be recycled. See below for more on customizing this behavior through the `createElement` and `recycleElement` APIs.
+By default, the elements inside the virtual scroller created in this example
+will be `<div>`s, and will be recycled. See below for more on customizing this
+behavior through the `createElement` and `recycleElement` APIs.
 
 Checkout more examples in [demo/index.html](./demo/index.html).
 
@@ -40,43 +50,65 @@ Checkout more examples in [demo/index.html](./demo/index.html).
 
 Type: `function(item: any, itemIndex: number) => Element`
 
-Set this property to configure the virtual scroller with a factory that creates an element the first time a given item at the specified index is ready to be displayed in the DOM.
+Set this property to configure the virtual scroller with a factory that creates
+an element the first time a given item at the specified index is ready to be
+displayed in the DOM.
 
-The default `createElement` will, upon first being invoked, search for the first `<template>` element child that itself has at least one child element in its template contents. If one exists, it will create new elements by cloning that child. Otherwise, it will create `<div>` elements. In either case, it will reuse recycled DOM nodes if `recycleElement` is left as its default value.
+The default `createElement` will, upon first being invoked, search for the
+first `<template>` element child that itself has at least one child element in
+its template contents. If one exists, it will create new elements by cloning
+that child. Otherwise, it will create `<div>` elements. In either case, it will
+reuse recycled DOM nodes if `recycleElement` is left as its default value.
 
-Changing this property from its default will automatically reset `recycleElement` to null, if `recycleElement` has been left as its default.
+Changing this property from its default will automatically reset
+`recycleElement` to null, if `recycleElement` has been left as its default.
 
 ### `updateElement` property
 
 Type: `function(child: Element, item: any, itemIndex: number)`
 
-Set this property to configure the virtual scroller with a function that will update the element with data from a given item at the specified index.
+Set this property to configure the virtual scroller with a function that will
+update the element with data from a given item at the specified index.
 
 This property is invoked in these scenarios:
 
-* The user scrolls the scroller, changing which items' elements are visible. In this case, `updateElement` is called for all of the newly-visible elements.
-* The developer changes the `itemSource` property.
-* The developer calls `itemsChanged()`, which will call `updateElement` for all currently-visible elements. See [below](#data-manipulation-using-itemschanged) for more on this.
+- The user scrolls the scroller, changing which items' elements are visible. In
+  this case, `updateElement` is called for all of the newly-visible elements.
+- The developer changes the `itemSource` property.
+- The developer calls `itemsChanged()`, which will call `updateElement` for all
+  currently-visible elements. See
+  [below](#data-manipulation-using-itemschanged) for more on this.
 
-The default `updateElement` sets the `textContent` of the child to be the given item, stringified. Almost all uses of `<virtual-scroller>` will want to change this behavior.
+The default `updateElement` sets the `textContent` of the child to be the given
+item, stringified. Almost all uses of `<virtual-scroller>` will want to change
+this behavior.
 
 ### `recycleElement` property
 
 Type: `function(child: Element, item: any, itemIndex: number)`
 
-The default `recycleElement` collects the item's element if it is no longer visible, and leaves it connected to the DOM in order to be reused by the default `createElement`.
+The default `recycleElement` collects the item's element if it is no longer
+visible, and leaves it connected to the DOM in order to be reused by the
+default `createElement`.
 
-Set this property to null to remove the item's element from the DOM when it is no longer visible, and to prevent recycling by the default `createElement`.
+Set this property to null to remove the item's element from the DOM when it is
+no longer visible, and to prevent recycling by the default `createElement`.
 
-Usually this property will be customized to introduce custom node recycling logic, as seen in [the example below](#custom-dom-recycling-using-recycleelement).
+Usually this property will be customized to introduce custom node recycling
+logic, as seen in [the example
+below](#custom-dom-recycling-using-recycleelement).
 
 ### `itemSource` property
 
 Type: `Array` or [`ItemSource`](#the-itemsource-class)
 
-Set this property to control how the scroller will map the visible indices into their corresponding items. The items are then provided to the various rendering customization functions: `createElement`, `updateElement`, `recycleElement`.
+Set this property to control how the scroller will map the visible indices into
+their corresponding items. The items are then provided to the various rendering
+customization functions: `createElement`, `updateElement`, `recycleElement`.
 
-If an array is provided, it will be converted to an `ItemSource` instance that returns the elements from the array, as if by using `ItemSource.fromArray(array)` (with no `key` argument).
+If an array is provided, it will be converted to an `ItemSource` instance that
+returns the elements from the array, as if by using
+`ItemSource.fromArray(array)` (with no `key` argument).
 
 ### `layout` property
 
@@ -89,34 +121,51 @@ One of:
 * "vertical-grid"
 * "horizontal-grid"
 
-Can also be set as an attribute on the element, e.g. `<virtual-scroller layout="horizontal-grid"></virtual-scroller>`
+Can also be set as an attribute on the element, e.g. `<virtual-scroller
+layout="horizontal-grid"></virtual-scroller>`
 
 ### `itemsChanged()` method
 
-This re-renders all of the currently-displayed elements, updating them from their source items using `updateElement` (which in turn consults the `itemSource`).
+This re-renders all of the currently-displayed elements, updating them from
+their source items using `updateElement` (which in turn consults the
+`itemSource`).
 
-This generally needs to be called any time the data to be displayed changes. This includes additions, removals, and modifications to the data. See our [examples below](#data-manipulation-using-itemschanged) for more information.
+This generally needs to be called any time the data to be displayed changes.
+This includes additions, removals, and modifications to the data. See our
+[examples below](#data-manipulation-using-itemschanged) for more information.
 
 ### `scrollToIndex(index: number, { position: string = "start" } = {})` method
 
 Scrolls to a specified index, optionally with a position, one of:
 
-* `"start"`: aligns the start of the item with the start of the visible portion of the scroller
-* `"center"`: aligns the center of the item with the center of the visible portion of the scroller
-* `"end"`: aligns the end of the item with the end of the visible portion of the scroller
-* `"nearest"`: if the item is before the center of the visible portion of the scroller, behaves like `"start"`; if it is after the center of the visible portion of the scroller, behaves like `"end"`
+- `"start"`: aligns the start of the item with the start of the visible portion
+  of the scroller
+- `"center"`: aligns the center of the item with the center of the visible
+  portion of the scroller
+- `"end"`: aligns the end of the item with the end of the visible portion of
+  the scroller
+- `"nearest"`: if the item is before the center of the visible portion of the
+  scroller, behaves like `"start"`; if it is after the center of the visible
+  portion of the scroller, behaves like `"end"`
 
-Note that what is considered the "start" and "end" of the scroller is dependent on the layout; for vertical layouts, start/end means top/bottom, while for horizontal layouts, they mean left/right.
+Note that what is considered the "start" and "end" of the scroller is dependent
+on the layout; for vertical layouts, start/end means top/bottom, while for
+horizontal layouts, they mean left/right.
 
 See [demo/scrolling.html](demo/scrolling.html) to see these behaviors in action.
 
-_Note: the options object design is inspired by [the options for `element.scrollIntoView()`](https://drafts.csswg.org/cssom-view/#dictdef-scrollintoviewoptions). We may in the future add a `behavior` option for smooth scrolling; see [#99](https://github.com/valdrinkoshi/virtual-scroller/issues/99)._
+_Note: the options object design is inspired by [the options for
+`element.scrollIntoView()`](https://drafts.csswg.org/cssom-view/#dictdef-scrollintoviewoptions).
+We may in the future add a `behavior` option for smooth scrolling; see
+[#99](https://github.com/valdrinkoshi/virtual-scroller/issues/99)._
 
 ### "`rangechange`" event
 
 Bubbles: false / Cancelable: false / Composed: false
 
-Fired when the scroller has finished rendering a new range of items, e.g. because the user scrolled. The event is an instance of `RangeChangeEvent`, which has the following properties:
+Fired when the scroller has finished rendering a new range of items, e.g.
+because the user scrolled. The event is an instance of `RangeChangeEvent`,
+which has the following properties:
 
 - `first`: a number giving the index of the first item currently rendered.
 - `last`: a number giving the index of the last item currently rendered.
@@ -125,7 +174,8 @@ Also see [the example below](#performing-actions-as-the-scroller-scrolls-using-t
 
 ### The `ItemSource` class
 
-The `ItemSource` class represents a way of translating indices into JavaScript values. You can create them like so:
+The `ItemSource` class represents a way of translating indices into JavaScript
+values. You can create them like so:
 
 ```js
 const source = new ItemSource({
@@ -135,7 +185,8 @@ const source = new ItemSource({
 });
 ```
 
-For example, to create an `ItemSource` that gets its items from a `contacts` array, and uses `contact.id` as the key, you could do
+For example, to create an `ItemSource` that gets its items from a `contacts`
+array, and uses `contact.id` as the key, you could do
 
 ```js
 const contactsSource = new ItemSource({
@@ -145,23 +196,33 @@ const contactsSource = new ItemSource({
 });
 ```
 
-There is also a factory method, `ItemSource.fromArray(array[, key])`, that makes this easier:
+There is also a factory method, `ItemSource.fromArray(array[, key])`, that
+makes this easier:
 
 ```js
 const contactsSource = ItemSource.fromArray(contacts, c => c.id);
 ```
 
-The `key` argument to `fromArray()` is called with an item, and should return a unique key for the object. If no `key` argument is given, then the item index is used as the key.
+The `key` argument to `fromArray()` is called with an item, and should return a
+unique key for the object. If no `key` argument is given, then the item index
+is used as the key.
 
-The main use of the `ItemSource` class is to be assigned to the `itemSource` property of a `<virtual-scroller>` element; as such, for now its only public API is a `length` property.
+The main use of the `ItemSource` class is to be assigned to the `itemSource`
+property of a `<virtual-scroller>` element; as such, for now its only public
+API is a `length` property.
 
 ## More examples
 
 ### Customizing element creation and updating with `<template>`
 
-If the user does nothing special, the default `createElement` callback will create and reuse `<div>` elements. There are several ways of getting more control over this process.
+If the user does nothing special, the default `createElement` callback will
+create and reuse `<div>` elements. There are several ways of getting more
+control over this process.
 
-First, you can use a `<template>` child element to declaratively set up your new element. This snippet creates a scrolling view onto `<section>` elements, which (per the default `updateElement` behavior) displays any items given to it, stringified:
+First, you can use a `<template>` child element to declaratively set up your
+new element. This snippet creates a scrolling view onto `<section>` elements,
+which (per the default `updateElement` behavior) displays any items given to
+it, stringified:
 
 ```html
 <virtual-scroller>
@@ -171,7 +232,8 @@ First, you can use a `<template>` child element to declaratively set up your new
 </virtual-scroller>
 ```
 
-By setting a custom `updateElement` behavior, you can leverage more interesting templates, for example:
+By setting a custom `updateElement` behavior, you can leverage more interesting
+templates, for example:
 
 ```html
 <virtual-scroller id="scroller">
@@ -195,7 +257,8 @@ By setting a custom `updateElement` behavior, you can leverage more interesting 
 </script>
 ```
 
-A useful pattern here is to encapsulate the details of updating your elements inside a custom element, for example:
+A useful pattern here is to encapsulate the details of updating your elements
+inside a custom element, for example:
 
 ```html
 <virtual-scroller>
@@ -213,13 +276,20 @@ A useful pattern here is to encapsulate the details of updating your elements in
 </script>
 ```
 
-_We could add a feature to make this even simpler, for custom-element cases like this. See [#101](https://github.com/valdrinkoshi/virtual-scroller/issues/101)._
+_We could add a feature to make this even simpler, for custom-element cases
+like this. See
+[#101](https://github.com/valdrinkoshi/virtual-scroller/issues/101)._
 
 Note that in all these examples, the elements are recycled.
 
 #### Relation to template instantiation proposal
 
-The [template instantiation](https://github.com/w3c/webcomponents/blob/gh-pages/proposals/Template-Instantiation.md) proposal is a still-evolving idea for how to provide native updating of `<template>` elements to the web platform. This seems like exactly the kind of thing we'd want to use with `<virtual-scroller>`, once it becomes ready. For example, one could replace the above example with
+The [template
+instantiation](https://github.com/w3c/webcomponents/blob/gh-pages/proposals/Template-Instantiation.md)
+proposal is a still-evolving idea for how to provide native updating of
+`<template>` elements to the web platform. This seems like exactly the kind of
+thing we'd want to use with `<virtual-scroller>`, once it becomes ready. For
+example, one could replace the above example with
 
 ```html
 <virtual-scroller id="scroller">
@@ -237,15 +307,30 @@ The [template instantiation](https://github.com/w3c/webcomponents/blob/gh-pages/
 </script>
 ```
 
-Since the template instantiation proposal is still in flux, and in particular the idea of a default processor which interprets `{{double-curly}}` syntax is controversial, we don't have any immediate plans for integrating the two proposals. But, we think it's important to preserve forward-compatibility, so if this capability eventually manifests in the web platform, the virtual-scroller spec can be upgraded to use it.
+Since the template instantiation proposal is still in flux, and in particular
+the idea of a default processor which interprets `{{double-curly}}` syntax is
+controversial, we don't have any immediate plans for integrating the two
+proposals. But, we think it's important to preserve forward-compatibility, so
+if this capability eventually manifests in the web platform, the
+virtual-scroller spec can be upgraded to use it.
 
-We see no serious obstacles to such a future upgrade. The only potential forward-compatibility issue to worry about is web pages that use `<template>`-based item creation, use the above double-curly syntax, and do not set a custom `updateElement`. Such pages would be changed from having their child element's `textContent` set into having the template stamped.
+We see no serious obstacles to such a future upgrade. The only potential
+forward-compatibility issue to worry about is web pages that use
+`<template>`-based item creation, use the above double-curly syntax, and do not
+set a custom `updateElement`. Such pages would be changed from having their
+child element's `textContent` set into having the template stamped.
 
-Such cases _should_ be exceedingly rare; since any text is overwritten by the default `updateElement`, writing double-curly text inside the `<template>` is rather nonsensical. If we're still concerned when that future day comes, we could require some explicit opt-in to the template-stamping, such as `<virtual-scroller autotemplate>` or similar.
+Such cases _should_ be exceedingly rare; since any text is overwritten by the
+default `updateElement`, writing double-curly text inside the `<template>` is
+rather nonsensical. If we're still concerned when that future day comes, we
+could require some explicit opt-in to the template-stamping, such as
+`<virtual-scroller autotemplate>` or similar.
 
 ### Customizing element creation and updating: using `createElement`
 
-If you want complete control over element creation, you can set a custom `createElement`. This could be useful if, for example, you have a completely static list, which you want to fill out ahead of time and never update again:
+If you want complete control over element creation, you can set a custom
+`createElement`. This could be useful if, for example, you have a completely
+static list, which you want to fill out ahead of time and never update again:
 
 ```js
 let myItems = ['a', 'b', 'c', 'd'];
@@ -262,7 +347,8 @@ scroller.updateElement = null;
 scroller.itemSource = myItems;
 ```
 
-Note that even if we invoke `itemsChanged()`, or change `itemSource`, nothing new would render in this case, because we have no `updateElement` behavior:
+Note that even if we invoke `itemsChanged()`, or change `itemSource`, nothing
+new would render in this case, because we have no `updateElement` behavior:
 
 ```js
 // Does nothing
@@ -278,11 +364,14 @@ requestAnimationFrame(() => {
 });
 ```
 
-_Note: we include `requestAnimationFrame` here to wait for `<virtual-scroller>` rendering._
+_Note: we include `requestAnimationFrame` here to wait for `<virtual-scroller>`
+rendering._
 
 ### Custom DOM recycling using `recycleElement`
 
-The default `createElement` and `recycleElement` functions will recycle the created DOM elements. You can also control this process on your own by setting a custom `recycleElement`:
+The default `createElement` and `recycleElement` functions will recycle the
+created DOM elements. You can also control this process on your own by setting
+a custom `recycleElement`:
 
 ```js
 const nodePool = [];
@@ -294,7 +383,8 @@ scroller.recycleElement = (child) => {
 };
 ```
 
-This example's only customization over the default is using `<section>` instead of `<div>`. So, it is equivalent to using
+This example's only customization over the default is using `<section>` instead
+of `<div>`. So, it is equivalent to using
 
 ```html
 <virtual-scroller>
@@ -302,17 +392,22 @@ This example's only customization over the default is using `<section>` instead 
 </virtual-scroller>
 ```
 
-But at least it illustrates the idea, and gives you a starting point for more advanced customizations.
+But at least it illustrates the idea, and gives you a starting point for more
+advanced customizations.
 
 ### Data manipulation using `itemsChanged()`
 
-The `<virtual-scroller>` element will automatically rerender the displayed items when `itemSource` changes. For example, to switch to a completely new set of items, you could do:
+The `<virtual-scroller>` element will automatically rerender the displayed
+items when `itemSource` changes. For example, to switch to a completely new set
+of items, you could do:
 
 ```js
 scroller.itemSource = newArray;
 ```
 
-If you want to continue using the same items and item source, but have updated any of them, you need to use `itemsChanged()` to notify the scroller about changes, and cause a rerender of currently-displayed items. For example:
+If you want to continue using the same items and item source, but have updated
+any of them, you need to use `itemsChanged()` to notify the scroller about
+changes, and cause a rerender of currently-displayed items. For example:
 
 ```js
 const myItems = ['a', 'b', 'c'];
@@ -327,9 +422,12 @@ scroller.itemsChanged();
 
 ### Efficient re-ordering using a custom item key
 
-`<virtual-scroller>` keeps track of the generated DOM via an internal key/element map to limit the number of created nodes.
+`<virtual-scroller>` keeps track of the generated DOM via an internal
+key/element map to limit the number of created nodes.
 
-Most of our examples so far have directly assigned an array to the `itemSource` property. For these cases, the default key is the item index. But you can set a custom key either by using the second argument to `fromArray`:
+Most of our examples so far have directly assigned an array to the `itemSource`
+property. For these cases, the default key is the item index. But you can set a
+custom key either by using the second argument to `fromArray`:
 
 ```js
 scroller.itemSource = ItemSource.fromArray(items, item => ...);
@@ -344,7 +442,8 @@ scroller.itemSource = new ItemSource({
 });
 ```
 
-To see how this helps, consider the following example. Imagine we have a list of 3 contacts:
+To see how this helps, consider the following example. Imagine we have a list
+of 3 contacts:
 
 ```js
 const myContacts = [{name: 'A'}, {name: 'B'}, {name:'C'}];
@@ -360,7 +459,8 @@ This renders 3 contacts, and the `<virtual-scroller>` key/element map is:
 2 → <div>C</div>
 ```
 
-Let's say we receive new data from the server, which has rearranged the contacts in a different order:
+Let's say we receive new data from the server, which has rearranged the
+contacts in a different order:
 
 ```js
 // Pretend this came from the server:
@@ -368,11 +468,14 @@ const newContacts = [{name: 'B'}, {name:'C'}, {name: 'A'}];
 scroller.itemSource = newContacts;
 ```
 
-With the default key function, we would re-update, relayout, and repaint all the contacts. Since none of the new contact objects are in the key/element map, we would need to call `createElement` again, once for each new contact.
+With the default key function, we would re-update, relayout, and repaint all
+the contacts. Since none of the new contact objects are in the key/element map,
+we would need to call `createElement` again, once for each new contact.
 
 This is suboptimal, as we just needed to move the first DOM node to the end.
 
-If instead we set the key computation appropriately when first setting `myContacts`, e.g. by doing
+If instead we set the key computation appropriately when first setting
+`myContacts`, e.g. by doing
 
 ```js
 scroller.itemSource = ItemSource.fromArray(myContacts, c => c.name);
@@ -392,13 +495,16 @@ Now if we update the `itemSource`, with
 scroller.itemSource = ItemSource.fromArray(newContacts, c => c.name);
 ```
 
-the `<virtual-scroller>` will notice that none of its keys changed, and so it can just reuse the same elements from the key/element map, while rearranging them appropriately. Thus we have avoided the expense of creating new ones.
+the `<virtual-scroller>` will notice that none of its keys changed, and so it
+can just reuse the same elements from the key/element map, while rearranging
+them appropriately. Thus we have avoided the expense of creating new ones.
 
 See [demo/sorting.html](demo/sorting.html) as an example implementation.
 
 ### Performing actions as the scroller scrolls using the "`rangechange`" event
 
-Listen for the "`rangechange`" event to get notified when the displayed items range changes.
+Listen for the "`rangechange`" event to get notified when the displayed items
+range changes.
 
 ```js
 scroller.addEventListener('rangechange', (event) => {
@@ -414,9 +520,15 @@ scroller.addEventListener('rangechange', (event) => {
 
 ### Scrolling
 
-`<virtual-scroller>` needs to be sized in order to determine how many items should be rendered. Its default height is 150px, similar to [CSS inline replaced elements](https://www.w3.org/TR/CSS2/visudet.html#inline-replaced-height) like images and iframes.
+`<virtual-scroller>` needs to be sized in order to determine how many items
+should be rendered. Its default height is 150px, similar to [CSS inline
+replaced
+elements](https://www.w3.org/TR/CSS2/visudet.html#inline-replaced-height) like
+images and iframes.
 
-Main document scrolling will be achievable through [`document.rootScroller`](https://github.com/bokand/root-scroller)
+Main document scrolling will be achievable through
+[`document.rootScroller`](https://github.com/bokand/root-scroller)
+
 ```html
 <virtual-scroller style="height: 100vh"></virtual-scroller>
 <script type="module">
@@ -426,7 +538,8 @@ Main document scrolling will be achievable through [`document.rootScroller`](htt
 
 ## Development
 
-To work on the proof-of-concept implementation, ensure you have installed the npm dependencies and serve from the project root
+To work on the proof-of-concept implementation, ensure you have installed the
+npm dependencies and serve from the project root
 
 ```sh
 $ npm install
@@ -435,4 +548,5 @@ $ python -m SimpleHTTPServer 8081
 
 Then, navigate to the url: http://localhost:8081/demo/
 
-For more documentation on the internal pieces that we use to implement our `<virtual-scroller>` prototype, see [DESIGN.md](./DESIGN.md).
+For more documentation on the internal pieces that we use to implement our
+`<virtual-scroller>` prototype, see [DESIGN.md](./DESIGN.md).

--- a/demo/basic-repeat/preact/basic-repeat.js
+++ b/demo/basic-repeat/preact/basic-repeat.js
@@ -19,6 +19,7 @@ export const Sample = RepeaterControl(class extends Component {
 
   render() {
     const {items, first, num, component, wrapper} = this.state;
-    return h(Repeat, {totalItems: items.length, first, num, component, wrapper});
+    return h(
+        Repeat, {totalItems: items.length, first, num, component, wrapper});
   }
 });

--- a/demo/contacts/contacts.js
+++ b/demo/contacts/contacts.js
@@ -98,7 +98,6 @@ export class Sample {
         }
         this._pool[type].push(child);
       },
-      // resetValue: this.resetValue
     });
   }
 

--- a/layouts/layout-1d-base.js
+++ b/layouts/layout-1d-base.js
@@ -294,7 +294,7 @@ export default class Layout extends EventTarget {
 
   _scrollPositionChanged(oldPos, newPos) {
     // When both values are bigger than the max scroll position, keep the
-    // current _scrollToIndexx, otherwise invalidate it.
+    // current _scrollToIndex, otherwise invalidate it.
     const maxPos = this._scrollSize - this._viewDim1;
     if (oldPos < maxPos || newPos < maxPos) {
       this._scrollToIndex = -1;

--- a/layouts/layout-1d-base.js
+++ b/layouts/layout-1d-base.js
@@ -44,7 +44,6 @@ export default class Layout extends EventTarget {
   set totalItems(num) {
     if (num !== this._totalItems) {
       this._totalItems = num;
-      this._maxIdx = num - 1;
       this._scheduleReflow();
     }
   }

--- a/layouts/layout-1d-grid.js
+++ b/layouts/layout-1d-grid.js
@@ -45,7 +45,6 @@ export default class Layout extends Layout1dBase {
     }
   }
 
-
   _defineGrid() {
     const {_spacing} = this;
     this._rolumns = Math.max(1, Math.floor(this._viewDim2 / this._itemDim2));

--- a/layouts/layout-1d.js
+++ b/layouts/layout-1d.js
@@ -47,8 +47,6 @@ export default class Layout extends Layout1dBase {
           }
         }
         this._tMeasured = this._tMeasured + delta;
-      } else {
-        // console.debug(`Could not find physical item for key ${key}`);
       }
     });
     if (!this._nMeasured) {

--- a/layouts/layout-1d.js
+++ b/layouts/layout-1d.js
@@ -90,12 +90,12 @@ export default class Layout extends Layout1dBase {
       return 0;
     }
     if (upper > this._scrollSize - this._viewDim1) {
-      return this._maxIdx;
+      return this._totalItems - 1;
     }
     return Math.max(
         0,
         Math.min(
-            this._maxIdx, Math.floor(((lower + upper) / 2) / this._delta)));
+            this._totalItems - 1, Math.floor(((lower + upper) / 2) / this._delta)));
   }
 
   _getAnchor(lower, upper) {
@@ -276,7 +276,7 @@ export default class Layout extends Layout1dBase {
     } else if (this._physicalMax >= this._scrollSize) {
       return (
           (this._physicalMax - this._scrollSize) +
-          ((this._maxIdx - this._last) * this._delta));
+          ((this._totalItems - 1 - this._last) * this._delta));
     }
     return 0;
   }

--- a/layouts/layout-1d.js
+++ b/layouts/layout-1d.js
@@ -322,8 +322,8 @@ export default class Layout extends Layout1dBase {
   _getItemPosition(idx) {
     return {
       [this._positionDim]: this._getPosition(idx),
-          [this._secondaryPositionDim]: 0
-    }
+      [this._secondaryPositionDim]: 0,
+    };
   }
 
   _getItemSize(idx) {

--- a/layouts/layout-1d.js
+++ b/layouts/layout-1d.js
@@ -65,8 +65,6 @@ export default class Layout extends Layout1dBase {
         Math.round(this._tMeasured / this._nMeasured);
   }
 
-  //
-
   _getMetrics(idx) {
     return (this._metrics[idx] = this._metrics[idx] || {});
   }
@@ -179,10 +177,9 @@ export default class Layout extends Layout1dBase {
   _getItems(lower, upper) {
     const items = this._newPhysicalItems;
 
-    // The anchorIdx is the anchor around which we reflow.
-    // It is designed to allow jumping to any point of the scroll size.
-    // We choose it once and stick with it until stable. first and last are
-    // deduced around it.
+    // The anchorIdx is the anchor around which we reflow. It is designed to
+    // allow jumping to any point of the scroll size. We choose it once and
+    // stick with it until stable. first and last are deduced around it.
     if (this._anchorIdx === null || this._anchorPos === null) {
       this._anchorIdx = this._getAnchor(lower, upper);
       this._anchorPos = this._getPosition(this._anchorIdx);
@@ -282,8 +279,8 @@ export default class Layout extends Layout1dBase {
   }
 
   _updateScrollSize() {
-    // Reuse previously calculated physical max, as it might be
-    // higher than the estimated size.
+    // Reuse previously calculated physical max, as it might be higher than the
+    // estimated size.
     super._updateScrollSize();
     this._scrollSize = Math.max(this._physicalMax, this._scrollSize);
   }

--- a/layouts/layout-1d.js
+++ b/layouts/layout-1d.js
@@ -93,7 +93,8 @@ export default class Layout extends Layout1dBase {
     return Math.max(
         0,
         Math.min(
-            this._totalItems - 1, Math.floor(((lower + upper) / 2) / this._delta)));
+            this._totalItems - 1,
+            Math.floor(((lower + upper) / 2) / this._delta)));
   }
 
   _getAnchor(lower, upper) {

--- a/smoke/flat/script.js
+++ b/smoke/flat/script.js
@@ -7,15 +7,6 @@ const items = new Array(200).fill({name: 'item'});
 const container = document.getElementById('container');
 
 const layout = new Layout({itemSize: {height: 50}});
-// render(
-//     html`${scroller({
-//       items,
-//       template: (item, idx) => html`
-//         <section><div class="title">${idx} - ${item.name}</div></section>
-//       `,
-//       layout,
-//     })}`,
-//     container);
 const pool = [];
 const config = {
   totalItems: items.length,
@@ -41,22 +32,5 @@ const config = {
     pool.push(section);
   }
 };
+
 window.scroller = new VirtualScroller(config);
-
-// document.body.style.minHeight = (innerHeight * 100) + 'px'
-
-// container.style.display = 'none';
-// setTimeout(() => {
-//   container.style.display = '';
-//   scroller.requestReset();
-// }, 1000);
-
-// setInterval(() => {
-//   Array.from(container.children).forEach(section => {
-//     section.appendChild(document.createElement('input'));
-//   })
-// }, 2000);
-
-// setTimeout(() => {
-//   scroller.splice(0, 0, {name: 'new'});
-// }, 1000);

--- a/smoke/nested/script.js
+++ b/smoke/nested/script.js
@@ -7,10 +7,7 @@ const items = new Array(40).fill({
   name: 'item',
   items: new Array(2).fill({
     name: 'inner item',
-    // items: new Array(4).fill({
-    //   name: 'inner inner item',
-    // })
-  })
+  }),
 });
 const container = document.getElementById('root');
 scrollerForContainer(container, items);
@@ -34,9 +31,6 @@ function scrollerForContainer(container, items) {
         child._title = child.querySelector('.title');
         child._container = child.querySelector('.innerContainer');
 
-        // child.id = `section_${idx}`;
-        // child._container.id = `innerContainer_${idx}`;
-
         if (items[idx].items) {
           child._container.classList.remove('innerContainer');
           scrollerForContainer(child._container, item.items);
@@ -45,9 +39,6 @@ function scrollerForContainer(container, items) {
       return child;
     },
     updateElement: (child, idx) => {
-      // child.id = `section_${idx}`;
-      // child._container.id = `innerContainer_${idx}`;
-
       child._title.textContent = `${idx} - ${items[idx].name}`;
       if (child._container._scroller) {
         child._container._scroller.totalItems = item.items.length;
@@ -59,19 +50,3 @@ function scrollerForContainer(container, items) {
   });
   container._scroller = scroller;
 }
-
-
-/* ------------- lit-html ------------- */
-
-// const template = (item, idx) => html`
-//   <section>
-//     <h3 class="title">${idx} - ${item.name}</h3>
-//     <div class="innerContainer">
-//       ${scroller(item.items, (innerItem, innerIdx) => html`
-//         <div>${idx}.${innerIdx} - ${innerItem.name}</div>
-//       `)}
-//     </div>
-//   </section>`;
-// render(html`${scroller(items, template)}`, container);
-// setTimeout(() => render(html `${scroller(items, template)}`, container),
-// 1000);

--- a/virtual-repeater.js
+++ b/virtual-repeater.js
@@ -112,7 +112,6 @@ export const Repeats = Superclass => class extends Superclass {
   get first() {
     return this._first;
   }
-
   set first(idx) {
     if (typeof idx !== 'number') {
       throw new Error('New value must be a number.');
@@ -128,7 +127,6 @@ export const Repeats = Superclass => class extends Superclass {
   get num() {
     return this._num;
   }
-
   set num(n) {
     if (typeof n !== 'number') {
       throw new Error('New value must be a number.');
@@ -144,7 +142,6 @@ export const Repeats = Superclass => class extends Superclass {
   get totalItems() {
     return this._totalItems;
   }
-
   set totalItems(num) {
     if (typeof num !== 'number') {
       throw new Error('New value must be a number.');
@@ -162,7 +159,6 @@ export const Repeats = Superclass => class extends Superclass {
   get _incremental() {
     return this.__incremental;
   }
-
   set _incremental(inc) {
     if (inc !== this.__incremental) {
       this.__incremental = inc;
@@ -436,24 +432,28 @@ export const Repeats = Superclass => class extends Superclass {
   }
 
   // Overridable abstractions for child manipulation
+
   /**
    * @protected
    */
   _node(child) {
     return child;
   }
+
   /**
    * @protected
    */
   _nextSibling(child) {
     return child.nextSibling;
   }
+
   /**
    * @protected
    */
   _insertBefore(child, referenceNode) {
     this._container.insertBefore(child, referenceNode);
   }
+
   /**
    * @protected
    */
@@ -461,6 +461,7 @@ export const Repeats = Superclass => class extends Superclass {
     const node = this._node(child);
     return node && node.parentNode === this._container;
   }
+
   /**
    * @protected
    */
@@ -469,6 +470,7 @@ export const Repeats = Superclass => class extends Superclass {
       child.style.display = 'none';
     }
   }
+
   /**
    * @protected
    */

--- a/virtual-repeater.js
+++ b/virtual-repeater.js
@@ -22,6 +22,8 @@ export const Repeats = Superclass => class extends Superclass {
     this._needsRemeasure = false;
     this._pendingRender = null;
 
+    this._container = null;
+
     // Contains child nodes in the rendered order.
     this._ordered = [];
     this._active = new Map();

--- a/virtual-repeater.js
+++ b/virtual-repeater.js
@@ -48,6 +48,7 @@ export const Repeats = Superclass => class extends Superclass {
     if (container === this._container) {
       return;
     }
+
     if (this._container) {
       // Remove children from old container.
       this._ordered.forEach((child) => this._removeChild(child));
@@ -113,12 +114,14 @@ export const Repeats = Superclass => class extends Superclass {
   }
 
   set first(idx) {
-    if (typeof idx === 'number') {
-      const newFirst = Math.max(0, Math.min(idx, this._totalItems - this._num));
-      if (newFirst !== this._first) {
-        this._first = newFirst;
-        this._scheduleRender();
-      }
+    if (typeof idx !== 'number') {
+      throw new Error('New value must be a number.');
+    }
+
+    const newFirst = Math.max(0, Math.min(idx, this._totalItems - this._num));
+    if (newFirst !== this._first) {
+      this._first = newFirst;
+      this._scheduleRender();
     }
   }
 
@@ -127,12 +130,14 @@ export const Repeats = Superclass => class extends Superclass {
   }
 
   set num(n) {
-    if (typeof n === 'number') {
-      if (n !== this._num) {
-        this._num = n;
-        this.first = this._first;
-        this._scheduleRender();
-      }
+    if (typeof n !== 'number') {
+      throw new Error('New value must be a number.');
+    }
+
+    if (n !== this._num) {
+      this._num = n;
+      this.first = this._first;
+      this._scheduleRender();
     }
   }
 
@@ -141,9 +146,13 @@ export const Repeats = Superclass => class extends Superclass {
   }
 
   set totalItems(num) {
+    if (typeof num !== 'number') {
+      throw new Error('New value must be a number.');
+    }
+
     // TODO(valdrin) should we check if it is a finite number?
     // Technically, Infinity would break Layout, not VirtualRepeater.
-    if (typeof num === 'number' && num !== this._totalItems) {
+    if (num !== this._totalItems) {
       this._totalItems = num;
       this.first = this._first;
       this.requestReset();

--- a/virtual-repeater.js
+++ b/virtual-repeater.js
@@ -200,9 +200,9 @@ export const Repeats = Superclass => class extends Superclass {
   }
 
   /**
-   * Returns those children that are about to be displayed and that
-   * require to be positioned. If reset or remeasure has been triggered,
-   * all children are returned.
+   * Returns those children that are about to be displayed and that require to
+   * be positioned. If reset or remeasure has been triggered, all children are
+   * returned.
    * @return {{indices:Array<number>,children:Array<Element>}}
    * @private
    */
@@ -219,8 +219,8 @@ export const Repeats = Superclass => class extends Superclass {
   }
 
   /**
-   * Measures each child bounds and builds a map of index/bounds to be passed to
-   * the `_measureCallback`
+   * Measures each child bounds and builds a map of index/bounds to be passed
+   * to the `_measureCallback`
    * @private
    */
   _measureChildren({indices, children}) {
@@ -455,6 +455,17 @@ export const Repeats = Superclass => class extends Superclass {
   }
 
   /**
+   * Remove child.
+   * Override to control child removal.
+   *
+   * @param {*} child
+   * @protected
+   */
+  _removeChild(child) {
+    child.parentNode.removeChild(child);
+  }
+
+  /**
    * @protected
    */
   _childIsAttached(child) {
@@ -481,27 +492,22 @@ export const Repeats = Superclass => class extends Superclass {
   }
 
   /**
-   *
    * @param {!Element} child
-   * @return {{width: number, height: number, marginTop: number, marginBottom: number, marginLeft: number, marginRight: number}} childMeasures
+   * @return {{
+   *   width: number,
+   *   height: number,
+   *   marginTop: number,
+   *   marginBottom: number,
+   *   marginLeft: number,
+   *   marginRight: number
+   * }} childMeasures
    * @protected
    */
   _measureChild(child) {
-    // offsetWidth doesn't take transforms in consideration,
-    // so we use getBoundingClientRect which does.
+    // offsetWidth doesn't take transforms in consideration, so we use
+    // getBoundingClientRect which does.
     const {width, height} = child.getBoundingClientRect();
     return Object.assign({width, height}, getMargins(child));
-  }
-
-  /**
-   * Remove child.
-   * Override to control child removal.
-   *
-   * @param {*} child
-   * @protected
-   */
-  _removeChild(child) {
-    child.parentNode.removeChild(child);
   }
 }
 

--- a/virtual-repeater.js
+++ b/virtual-repeater.js
@@ -10,13 +10,10 @@ export const Repeats = Superclass => class extends Superclass {
     this._measureCallback = null;
 
     this._totalItems = 0;
-    // Consider renaming this. firstVisibleIndex?
-    this._first = 0;
     // Consider renaming this. count? visibleElements?
     this._num = Infinity;
-
-    this.__incremental = false;
-
+    // Consider renaming this. firstVisibleIndex?
+    this._first = 0;
     this._last = 0;
     this._prevFirst = 0;
     this._prevLast = 0;
@@ -27,7 +24,6 @@ export const Repeats = Superclass => class extends Superclass {
 
     // Contains child nodes in the rendered order.
     this._ordered = [];
-    // this._pool = [];
     this._active = new Map();
     this._prevActive = new Map();
     // Both used for recycling purposes.
@@ -35,6 +31,8 @@ export const Repeats = Superclass => class extends Superclass {
     this._childToKey = new WeakMap();
     // Used to keep track of measures by index.
     this._indexToMeasure = {};
+
+    this.__incremental = false;
 
     if (config) {
       Object.assign(this, config);
@@ -481,8 +479,6 @@ export const Repeats = Superclass => class extends Superclass {
     // offsetWidth doesn't take transforms in consideration,
     // so we use getBoundingClientRect which does.
     const {width, height} = child.getBoundingClientRect();
-    // console.debug(`_measureChild #${this._container.id} > #${
-    //     child.id}: height: ${height}px`);
     return Object.assign({width, height}, getMargins(child));
   }
 
@@ -500,7 +496,6 @@ export const Repeats = Superclass => class extends Superclass {
 
 function getMargins(el) {
   const style = window.getComputedStyle(el);
-  // console.log(el.id, style.position);
   return {
     marginLeft: getMarginValue(style.marginLeft),
     marginRight: getMarginValue(style.marginRight),

--- a/virtual-repeater.js
+++ b/virtual-repeater.js
@@ -203,7 +203,7 @@ export const Repeats = Superclass => class extends Superclass {
    * Returns those children that are about to be displayed and that require to
    * be positioned. If reset or remeasure has been triggered, all children are
    * returned.
-   * @return {{indices:Array<number>,children:Array<Element>}}
+   * @return {{indices: Array<number>, children: Array<Element>}}
    * @private
    */
   get _toMeasure() {
@@ -226,7 +226,7 @@ export const Repeats = Superclass => class extends Superclass {
   _measureChildren({indices, children}) {
     let pm = children.map(
         (c, i) => this._indexToMeasure[indices[i]] || this._measureChild(c));
-    const mm = /** @type {{ number: { width: number, height: number } }} */
+    const mm = /** @type {{number: {width: number, height: number}}} */
         (pm.reduce((out, cur, i) => {
           out[indices[i]] = this._indexToMeasure[indices[i]] = cur;
           return out;
@@ -497,9 +497,9 @@ export const Repeats = Superclass => class extends Superclass {
    *   width: number,
    *   height: number,
    *   marginTop: number,
+   *   marginRight: number,
    *   marginBottom: number,
    *   marginLeft: number,
-   *   marginRight: number
    * }} childMeasures
    * @protected
    */
@@ -514,16 +514,16 @@ export const Repeats = Superclass => class extends Superclass {
 function getMargins(el) {
   const style = window.getComputedStyle(el);
   return {
-    marginLeft: getMarginValue(style.marginLeft),
-    marginRight: getMarginValue(style.marginRight),
     marginTop: getMarginValue(style.marginTop),
+    marginRight: getMarginValue(style.marginRight),
     marginBottom: getMarginValue(style.marginBottom),
+    marginLeft: getMarginValue(style.marginLeft),
   };
 }
 
 function getMarginValue(value) {
   value = value ? parseFloat(value) : NaN;
-  return value !== value ? 0 : value;
+  return Number.isNaN(value) ? 0 : value;
 }
 
 export const VirtualRepeater = Repeats(class {});

--- a/virtual-repeater.js
+++ b/virtual-repeater.js
@@ -353,17 +353,17 @@ export const Repeats = Superclass => class extends Superclass {
    * @private
    */
   _reset(first, last) {
-    const len = last - first + 1;
     // Explain why swap prevActive with active - affects _assignChild.
     const prevActive = this._active;
     this._active = this._prevActive;
     this._prevActive = prevActive;
-    let currentMarker = this._firstChild;
+
     this._ordered.length = 0;
-    for (let n = 0; n < len; n++) {
-      const idx = first + n;
-      const child = this._assignChild(idx);
+    let currentMarker = this._firstChild;
+    for (let i = first; i <= last; i++) {
+      const child = this._assignChild(i);
       this._ordered.push(child);
+
       if (currentMarker) {
         if (currentMarker === this._node(child)) {
           currentMarker = this._nextSibling(child);
@@ -373,8 +373,9 @@ export const Repeats = Superclass => class extends Superclass {
       } else if (!this._childIsAttached(child)) {
         this._insertBefore(child, null);
       }
+
       if (this.updateElement) {
-        this.updateElement(child, idx);
+        this.updateElement(child, i);
       }
     }
   }

--- a/virtual-scroller-element.js
+++ b/virtual-scroller-element.js
@@ -158,8 +158,8 @@ export class VirtualScrollerElement extends HTMLElement {
   }
 
   [_render]() {
-    // Wait first connected as scroller needs to measure
-    // sizes of container and children.
+    // Wait first connected as scroller needs to measure sizes of container and
+    // children.
     if (!this[_firstConnected] || !this.createElement) {
       return;
     }

--- a/virtual-scroller.js
+++ b/virtual-scroller.js
@@ -177,9 +177,6 @@ export const RepeatsAndScrolls = Superclass => class extends Repeats
    * @protected
    */
   _render() {
-    // console.time(`render ${this._containerElement.localName}#${
-    //     this._containerElement.id}`);
-
     this._childrenRO.disconnect();
 
     // Update layout properties before rendering to have correct
@@ -216,9 +213,6 @@ export const RepeatsAndScrolls = Superclass => class extends Repeats
     // measured the children.
     this._skipNextChildrenSizeChanged = true;
     this._kids.forEach(child => this._childrenRO.observe(child));
-
-    // console.timeEnd(`render ${this._containerElement.localName}#${
-    //     this._containerElement.id}`);
   }
 
   /**
@@ -364,8 +358,6 @@ export const RepeatsAndScrolls = Superclass => class extends Repeats
       const child = kids[idx];
       if (child) {
         const {top, left} = pos[key];
-        // console.debug(`_positionChild #${this._container.id} >
-        // #${child.id}: top ${top}`);
         child.style.position = 'absolute';
         child.style.transform = `translate(${left}px, ${top}px)`;
       }
@@ -426,7 +418,6 @@ export const RepeatsAndScrolls = Superclass => class extends Repeats
   _containerSizeChanged(size) {
     const {width, height} = size;
     this._containerSize = {width, height};
-    // console.debug('container changed size', this._containerSize);
     this._scheduleUpdateView();
   }
   /**

--- a/virtual-scroller.js
+++ b/virtual-scroller.js
@@ -258,6 +258,7 @@ export const RepeatsAndScrolls = Superclass => class extends Repeats
         console.warn('event not handled', event);
     }
   }
+
   /**
    * @return {!Element}
    * @private
@@ -286,6 +287,7 @@ export const RepeatsAndScrolls = Superclass => class extends Repeats
   get _kids() {
     return this._ordered;
   }
+
   /**
    * @private
    */
@@ -293,6 +295,7 @@ export const RepeatsAndScrolls = Superclass => class extends Repeats
     this._needsUpdateView = true;
     this._scheduleRender();
   }
+
   /**
    * @private
    */
@@ -334,6 +337,7 @@ export const RepeatsAndScrolls = Superclass => class extends Repeats
     this._layout.viewportSize = {width, height};
     this._layout.viewportScroll = {top, left};
   }
+
   /**
    * @private
    */
@@ -348,6 +352,7 @@ export const RepeatsAndScrolls = Superclass => class extends Repeats
       style.minHeight = size && size.height ? size.height + 'px' : null;
     }
   }
+
   /**
    * @private
    */
@@ -363,6 +368,7 @@ export const RepeatsAndScrolls = Superclass => class extends Repeats
       }
     });
   }
+
   /**
    * @private
    */
@@ -376,6 +382,7 @@ export const RepeatsAndScrolls = Superclass => class extends Repeats
       this._notifyStable();
     }
   }
+
   /**
    * @protected
    */
@@ -392,6 +399,7 @@ export const RepeatsAndScrolls = Superclass => class extends Repeats
     }
     return this._containerSize.width > 0 || this._containerSize.height > 0;
   }
+
   /**
    * @private
    */
@@ -403,6 +411,7 @@ export const RepeatsAndScrolls = Superclass => class extends Repeats
       window.scroll(window.scrollX - err.left, window.scrollY - err.top);
     }
   }
+
   /**
    * @protected
    */
@@ -412,6 +421,7 @@ export const RepeatsAndScrolls = Superclass => class extends Repeats
     this._container.dispatchEvent(
         new RangeChangeEvent('rangechange', {first, last}));
   }
+
   /**
    * @private
    */
@@ -420,6 +430,7 @@ export const RepeatsAndScrolls = Superclass => class extends Repeats
     this._containerSize = {width, height};
     this._scheduleUpdateView();
   }
+
   /**
    * @private
    */

--- a/virtual-scroller.js
+++ b/virtual-scroller.js
@@ -179,8 +179,8 @@ export const RepeatsAndScrolls = Superclass => class extends Repeats
   _render() {
     this._childrenRO.disconnect();
 
-    // Update layout properties before rendering to have correct
-    // first, num, scroll size, children positions.
+    // Update layout properties before rendering to have correct first, num,
+    // scroll size, children positions.
     this._layout.totalItems = this.totalItems;
     if (this._needsUpdateView) {
       this._needsUpdateView = false;

--- a/virtual-scroller.js
+++ b/virtual-scroller.js
@@ -18,6 +18,7 @@ export const RepeatsAndScrolls = Superclass => class extends Repeats
 (Superclass) {
   constructor(config) {
     super();
+
     this._num = 0;
     this._first = -1;
     this._last = -1;
@@ -25,12 +26,8 @@ export const RepeatsAndScrolls = Superclass => class extends Repeats
     this._prevLast = -1;
 
     this._needsUpdateView = false;
-    this._containerElement = null;
     this._layout = null;
     this._scrollTarget = null;
-    // Keep track of original inline style of the container, so it can be
-    // restored when container is changed.
-    this._containerInlineStyle = null;
     // A sentinel element that sizes the container when it is a scrolling
     // element.
     this._sizer = null;
@@ -39,6 +36,10 @@ export const RepeatsAndScrolls = Superclass => class extends Repeats
     this._scrollErr = null;
     this._childrenPos = null;
 
+    this._containerElement = null;
+    // Keep track of original inline style of the container, so it can be
+    // restored when container is changed.
+    this._containerInlineStyle = null;
     this._containerSize = null;
     this._containerRO = new ResizeObserver(
         (entries) => this._containerSizeChanged(entries[0].contentRect));
@@ -53,7 +54,7 @@ export const RepeatsAndScrolls = Superclass => class extends Repeats
   }
 
   get container() {
-    return this._container;
+    return super.container;
   }
   set container(container) {
     super.container = container;

--- a/virtual-scroller.js
+++ b/virtual-scroller.js
@@ -28,11 +28,11 @@ export const RepeatsAndScrolls = Superclass => class extends Repeats
     this._containerElement = null;
     this._layout = null;
     this._scrollTarget = null;
-    // Keep track of original inline style of the container,
-    // so it can be restored when container is changed.
+    // Keep track of original inline style of the container, so it can be
+    // restored when container is changed.
     this._containerInlineStyle = null;
-    // A sentinel element that sizes the container when
-    // it is a scrolling element.
+    // A sentinel element that sizes the container when it is a scrolling
+    // element.
     this._sizer = null;
     // Layout provides these values, we set them on _render().
     this._scrollSize = null;
@@ -216,9 +216,8 @@ export const RepeatsAndScrolls = Superclass => class extends Repeats
   }
 
   /**
-   * Position children before they get measured.
-   * Measuring will force relayout, so by positioning
-   * them first, we reduce computations.
+   * Position children before they get measured. Measuring will force relayout,
+   * so by positioning them first, we reduce computations.
    * @protected
    */
   _didRender() {
@@ -265,10 +264,8 @@ export const RepeatsAndScrolls = Superclass => class extends Repeats
    */
   _createContainerSizer() {
     const sizer = document.createElement('div');
-    // When the scrollHeight is large, the height
-    // of this element might be ignored.
-    // Setting content and font-size ensures the element
-    // has a size.
+    // When the scrollHeight is large, the height of this element might be
+    // ignored. Setting content and font-size ensures the element has a size.
     Object.assign(sizer.style, {
       position: 'absolute',
       margin: '-2px 0 0 0',
@@ -280,7 +277,7 @@ export const RepeatsAndScrolls = Superclass => class extends Repeats
     return sizer;
   }
 
-  // Rename _ordered to _kids?
+  // TODO: Rename _ordered to _kids?
   /**
    * @protected
    */
@@ -391,8 +388,8 @@ export const RepeatsAndScrolls = Superclass => class extends Repeats
       return false;
     }
     // NOTE: we're about to render, but the ResizeObserver didn't execute yet.
-    // Since we want to keep rAF timing, we compute _containerSize now.
-    // Would be nice to have a way to flush ResizeObservers
+    // Since we want to keep rAF timing, we compute _containerSize now. Would
+    // be nice to have a way to flush ResizeObservers.
     if (this._containerSize === null) {
       const {width, height} = this._containerElement.getBoundingClientRect();
       this._containerSize = {width, height};


### PR DESCRIPTION
To get adjusted to the code, I've been going through trying to find things to clean up. There are a few actual code changes in addition to the formatting / spacing stuff:
- Repeater:
  - Removed `_manageDom` and `_maintainDomOrder`, which aren't modified anywhere in the repo, and `_measuringId`, which was never referenced.
  - Setters that previously did nothing if you assigned the wrong type of value now throw.
  - Simplified some loop indexing stuff in `_reset`.
- Scroller:
  - The `container` getter is now `return super.container;` instead of `return this._container;`.
- Layout1D:
  - Removed `_maxIdx`, which was always `_totalItems - 1`.