### PR TITLE
Use node's http-server instead of python's SimpleHTTPServer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,7 +543,8 @@ npm dependencies and serve from the project root
 
 ```sh
 $ npm install
-$ node_modules/http-server/bin/http-server -p 8081
+$ npm install -g http-server   // If http-server is not installed.
+$ http-server -p 8081
 ```
 
 Then, navigate to the url: http://localhost:8081/demo/

--- a/README.md
+++ b/README.md
@@ -543,7 +543,7 @@ npm dependencies and serve from the project root
 
 ```sh
 $ npm install
-$ python -m SimpleHTTPServer 8081
+$ node_modules/http-server/bin/http-server -p 8081
 ```
 
 Then, navigate to the url: http://localhost:8081/demo/

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "directories": {},
   "devDependencies": {
     "clang-format": "^1.2",
-    "http-server": "latest",
     "lit-html": "latest",
     "preact": "^8.2.6",
     "streaming-spec": "github:jakearchibald/streaming-html-spec#master"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "directories": {},
   "devDependencies": {
     "clang-format": "^1.2",
-    "http-server": "latest"
+    "http-server": "latest",
     "lit-html": "latest",
     "preact": "^8.2.6",
     "streaming-spec": "github:jakearchibald/streaming-html-spec#master"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "directories": {},
   "devDependencies": {
     "clang-format": "^1.2",
+    "http-server": "latest"
     "lit-html": "latest",
     "preact": "^8.2.6",
     "streaming-spec": "github:jakearchibald/streaming-html-spec#master"


### PR DESCRIPTION
SimpleHTTPServer is single-threaded and often blocks for 20s on
keep-alive connections from chrome.